### PR TITLE
Add RFC5905 sanity checks for NTP packets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 
 go:
   - 1.8
+  - 1.9
   - tip
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -9,11 +9,16 @@ to connect to a remote NTP server and request the current time.
 
 To request the current time, simply do the following:
 ```go
-time, err := ntp.Time("pool.ntp.org")
+time, err := ntp.Time("0.beevik-ntp.pool.ntp.org")
 ```
 
 To request the current time along with additional metadata, use the Query
 function:
 ```go
-response, err := ntp.Query("pool.ntp.org")
+response, err := ntp.Query("0.beevik-ntp.pool.ntp.org")
 ```
+
+NB: if you want to use the NTP Pool in your software you should request your
+own [vendor zone](http://www.pool.ntp.org/en/vendors.html).  You **must
+absolutely not use the default pool.ntp.org zone names** as the default
+configuration in your application or appliance.


### PR DESCRIPTION
I suggest to add these sanity checks to sntp client library as it was suggested during IRC discussion of prometheus/node_exporter#655 that these checks may be useful to other users of the library.

I also add code branch to discard packets with clock ticking backwards.

If NTP server reports it's clock ticking backwards it's absolutely unsuitable as a time source (or just sends random data as a reply).

If NTP client has clock ticking backwards, it should use monotonic clock, but monotonic clock are only available with Go 1.9 that is not released yet, so these packets are also dropped as time estimates are obviously wrong. It may be considered regression as Response.Time still may be usable, although Offset and RTT are obviously meaningless in this case. I think that the way to go is to drop these packets right now and upgrade to monotonic clock after Go 1.9 release.

Also, I'm unsure if `Time` and `TimeV` should run `IsUsable()` sanity check before returning server time. I decided **not** to run it.