### PR TITLE
Don't 'reset' stratum to 16 when it's 0

### DIFF
--- a/ntp.go
+++ b/ntp.go
@@ -289,11 +289,6 @@ func parseTime(m *msg, dst ntpTime) *Response {
 	r.RootDistance = r.rootDistance()
 	r.CausalityViolation = r.causalityViolation()
 
-	// https://tools.ietf.org/html/rfc5905#section-7.3
-	if r.Stratum == 0 {
-		r.Stratum = MaxStratum
-	}
-
 	return r
 }
 


### PR DESCRIPTION
0 means 'I am a rate limiting message' which shouldn't get lost
to clients.

Fixes #18