### PR TITLE
Bring calculations into better alignment with RFC.

### DIFF
--- a/ntp.go
+++ b/ntp.go
@@ -23,9 +23,6 @@ import (
 const (
 	// MaxStratum is the largest allowable NTP stratum value.
 	MaxStratum = 16
-
-	// MaxRootDistance is the largest possible root distance (in seconds).
-	MaxRootDistance = 2.96608
 )
 
 // The LeapIndicator is used to warn if a leap second should be inserted

--- a/ntp.go
+++ b/ntp.go
@@ -215,6 +215,11 @@ func (r *Response) Validate() error {
 		return errors.New("invalid stratum received")
 	}
 
+	// Handle invalid leap second indicator.
+	if r.Leap == LeapNotInSync {
+		return errors.New("invalid leap second")
+	}
+
 	// Estimate the "freshness" of the time. If it exceeds the maximum
 	// polling interval (~36 hours), then it cannot be considered "fresh".
 	freshness := r.Time.Sub(r.ReferenceTime)

--- a/ntp.go
+++ b/ntp.go
@@ -395,7 +395,7 @@ func getTime(host string, opt QueryOptions) (*msg, ntpTime, error) {
 func parseTime(m *msg, recvTime ntpTime) *Response {
 	r := &Response{
 		Time:           m.TransmitTime.Time(),
-		RTT:            rtt(m.Precision, m.OriginTime, m.ReceiveTime, m.TransmitTime, recvTime),
+		RTT:            rtt(m.OriginTime, m.ReceiveTime, m.TransmitTime, recvTime),
 		ClockOffset:    offset(m.OriginTime, m.ReceiveTime, m.TransmitTime, recvTime),
 		Poll:           toInterval(m.Poll),
 		Precision:      toInterval(m.Precision),
@@ -422,14 +422,14 @@ func parseTime(m *msg, recvTime ntpTime) *Response {
 //   xmt = Transmit Timestamp (server reply time)
 //   dst = Destination Timestamp (client receive time)
 
-func rtt(prec int8, org, rec, xmt, dst ntpTime) time.Duration {
+func rtt(org, rec, xmt, dst ntpTime) time.Duration {
 	// round trip delay time
 	//   rtt = (dst-org) - (xmt-rec)
 	a := dst.Time().Sub(org.Time())
 	b := xmt.Time().Sub(rec.Time())
 	rtt := a - b
-	if rtt < toInterval(prec) {
-		rtt = toInterval(prec)
+	if rtt < 0 {
+		rtt = 0
 	}
 	return rtt
 }

--- a/ntp.go
+++ b/ntp.go
@@ -210,9 +210,12 @@ type Response struct {
 // Validate checks if the response is valid for the purposes of time
 // synchronization.
 func (r *Response) Validate() error {
-	// Check for an illegal stratum value.
-	if r.Stratum > MaxStratum {
-		return errors.New("invalid stratum in response")
+	// Check for illegal stratum values.
+	if r.Stratum == 0 {
+		return errors.New("kiss of death received")
+	}
+	if r.Stratum >= MaxStratum {
+		return errors.New("invalid stratum received")
 	}
 
 	// Estimate the "freshness" of the time. If it exceeds the maximum

--- a/ntp.go
+++ b/ntp.go
@@ -239,7 +239,7 @@ func (r *Response) Validate() error {
 
 	// If the packet's transmit time is before the server's reference
 	// time, it's invalid.
-	if r.Time.Before(r.ReferenceTime) {
+	if r.Time.Before(r.ReferenceTime) || r.Time == ntpEpoch || r.ReferenceTime == ntpEpoch {
 		return errors.New("invalid time reported")
 	}
 

--- a/ntp_test.go
+++ b/ntp_test.go
@@ -21,9 +21,15 @@ func isNil(t *testing.T, err error) bool {
 	case err == nil:
 		return true
 	case strings.Contains(err.Error(), "timeout"):
+		// log instead of error, so test isn't failed
 		t.Logf("[%s] Query timeout: %s", host, err)
 		return false
+	case strings.Contains(err.Error(), "kiss of death"):
+		// log instead of error, so test isn't failed
+		t.Logf("[%s] Query kiss of death: %s", host, err)
+		return false
 	default:
+		// error, so test fails
 		t.Errorf("[%s] Query failed: %s", host, err)
 		return false
 	}

--- a/ntp_test.go
+++ b/ntp_test.go
@@ -81,14 +81,6 @@ func TestQuery(t *testing.T) {
 		return
 	}
 
-	if r.Stratum > 16 {
-		t.Errorf("[%s] Invalid stratum: %d", host, r.Stratum)
-	}
-
-	if r.RTT < time.Duration(0) {
-		t.Errorf("[%s] Negative round trip time: %v", host, r.RTT)
-	}
-
 	t.Logf("[%s]  LocalTime: %v", host, time.Now())
 	t.Logf("[%s]   XmitTime: %v", host, r.Time)
 	t.Logf("[%s]    RefTime: %v", host, r.ReferenceTime)

--- a/ntp_test.go
+++ b/ntp_test.go
@@ -38,13 +38,15 @@ func isNil(t *testing.T, err error) bool {
 func assertValid(t *testing.T, r *Response) {
 	err := r.Validate()
 	if err != nil {
-		t.Errorf("[%s] Query invalid: %s\n", host, err)
+		t.Errorf("[%s] Response invalid: %s\n", host, err)
 	}
 }
 
 func assertInvalid(t *testing.T, r *Response) {
 	err := r.Validate()
-	assert.NotNil(t, err)
+	if err == nil {
+		t.Errorf("[%s] Response unexpectedly valid\n", host)
+	}
 }
 
 func TestTime(t *testing.T) {

--- a/ntp_test.go
+++ b/ntp_test.go
@@ -141,8 +141,8 @@ func TestValidate(t *testing.T) {
 	r = parseTime(&m, 22<<32)
 	assert.NotNil(t, r)
 	assertValid(t, r)
-	assert.Equal(t, r.RTT, 500*time.Millisecond)
-	assert.Equal(t, r.RootDistance, 8250*time.Millisecond)
+	assert.Equal(t, r.RTT, 0*time.Second)
+	assert.Equal(t, r.RootDistance, 8*time.Second)
 }
 
 func TestBadServerPort(t *testing.T) {


### PR DESCRIPTION
RTT calculation can no longer yield a result less than the precision value.
Account for minimum dispersion in the calculation of the root distance.
Updated the comments for all calculated fields to better match the RFC.
Removed casuality violation until I have a better understanding of how it's useful.