### PR TITLE
fix: offset calculation for NTP responses

### DIFF
--- a/ntp.go
+++ b/ntp.go
@@ -749,9 +749,18 @@ func rtt(org, rec, xmt, dst ntpTime) time.Duration {
 func offset(org, rec, xmt, dst ntpTime) time.Duration {
 	// local clock offset
 	//   offset = ((rec-org) + (xmt-dst)) / 2
-	a := rec.Time().Sub(org.Time())
-	b := xmt.Time().Sub(dst.Time())
-	return (a + b) / time.Duration(2)
+	//
+	// see	https://www.eecis.udel.edu/~mills/time.html for more details
+	// the input is 64 unsigned numbers, output is 63 bits signed (precision)
+	a := int64(rec) - int64(org)
+	b := int64(xmt) - int64(dst)
+	d := (a + b) / 2
+
+	if d > 0 {
+		return ntpTime(d).Duration()
+	} else {
+		return -ntpTime(-d).Duration()
+	}
 }
 
 func minError(org, rec, xmt, dst ntpTime) time.Duration {


### PR DESCRIPTION
The problem here is that `time.Duration` and `time.Time` types don't exactly match the NTP 64-bit time value, so the expected calculations for big time jumps (including across NTP eras) don't work properly.

See:

* https://www.eecis.udel.edu/~mills/y2k.html
* https://www.eecis.udel.edu/~mills/time.html

Ref: https://github.com/siderolabs/talos/issues/8771